### PR TITLE
autofix: issue #16 – [Bug] HR角色增加部門管理模組，讓HR可以新增修改刪除部門

### DIFF
--- a/.autofix/issue-16.md
+++ b/.autofix/issue-16.md
@@ -1,0 +1,41 @@
+# Auto-Fix: Issue #16
+
+**Issue title:** [Bug] HR角色增加部門管理模組，讓HR可以新增修改刪除部門
+**Issue URL:** https://github.com/TH0nnz/sdd-demo-v3/issues/16
+
+## Issue body
+
+### 類型
+
+add
+
+### 重現步驟
+
+使用HR登入後，讓HR可以新增修改刪除部門，因為現在沒有實作這方面的功能，所以要新增功能
+
+### 實際結果
+
+因為現在沒有實作這方面的功能，所以要新增功能
+
+### 預期結果
+
+HR角色增加部門管理模組，讓HR可以新增修改刪除部門
+
+### 相關元件 / 檔案
+
+_No response_
+
+### 補充
+
+_No response_
+
+## Triggering comment
+
+/fix
+
+
+**Comment URL:** https://github.com/TH0nnz/sdd-demo-v3/issues/16#issuecomment-3976367722
+
+---
+*This file was created automatically by the auto-fix workflow.
+Replace this file (or the relevant source files) with the actual fix.*


### PR DESCRIPTION
Automated fix proposed in response to issue #16.

### Issue
**[Bug] HR角色增加部門管理模組，讓HR可以新增修改刪除部門**
https://github.com/TH0nnz/sdd-demo-v3/issues/16

### Triggered by comment
> /fix
> 

https://github.com/TH0nnz/sdd-demo-v3/issues/16#issuecomment-3976367722

---
*Review and update the scaffolded file in `.autofix/` (or the relevant source files) before merging.*